### PR TITLE
Update workflows to Java 11

### DIFF
--- a/.github/workflows/publish_twopanelayout_ado.yml
+++ b/.github/workflows/publish_twopanelayout_ado.yml
@@ -26,10 +26,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache Gradle packages
         uses: actions/cache@v2

--- a/.github/workflows/publish_twopanelayout_mavencentral.yml
+++ b/.github/workflows/publish_twopanelayout_mavencentral.yml
@@ -27,10 +27,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache Gradle packages
         uses: actions/cache@v2


### PR DESCRIPTION
Update workflows to use Java 11 that is needed when building Jetpack Compose with gradle