### PR TITLE
Ensure all pages can be viewed in different orientations

### DIFF
--- a/ComposeSamples/TwoPage/src/main/java/com/microsoft/device/display/samples/twopage/ui/home/FirstPage.kt
+++ b/ComposeSamples/TwoPage/src/main/java/com/microsoft/device/display/samples/twopage/ui/home/FirstPage.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.MaterialTheme.typography
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -36,6 +37,7 @@ fun FirstPageContent() {
     Spacer(modifier = Modifier.height(10.dp))
     Text(
         text = stringResource(R.string.article_title),
+        color = MaterialTheme.colors.onBackground,
         style = typography.h5
     )
     Spacer(modifier = Modifier.requiredHeight(5.dp))
@@ -57,6 +59,7 @@ fun FirstPageContent() {
     Spacer(modifier = Modifier.requiredHeight(5.dp))
     Text(
         text = stringResource(R.string.two_page_page1_text),
+        color = MaterialTheme.colors.onBackground,
         style = typography.body1
     )
     AlignedCaption(

--- a/ComposeSamples/TwoPage/src/main/java/com/microsoft/device/display/samples/twopage/ui/home/FourthPage.kt
+++ b/ComposeSamples/TwoPage/src/main/java/com/microsoft/device/display/samples/twopage/ui/home/FourthPage.kt
@@ -26,18 +26,22 @@ fun FourthPage(modifier: Modifier) {
 fun FourthPageContent() {
     Text(
         text = stringResource(R.string.two_page_page4_title1),
+        color = MaterialTheme.colors.onBackground,
         style = MaterialTheme.typography.h6
     )
     Text(
         text = stringResource(R.string.two_page_page4_text1),
+        color = MaterialTheme.colors.onBackground,
         style = MaterialTheme.typography.body2
     )
     Text(
         text = stringResource(R.string.two_page_page4_title2),
+        color = MaterialTheme.colors.onBackground,
         style = MaterialTheme.typography.h6
     )
     Text(
         text = stringResource(R.string.two_page_page4_text2),
+        color = MaterialTheme.colors.onBackground,
         style = MaterialTheme.typography.body2
     )
     AlignedCaption(

--- a/ComposeSamples/TwoPage/src/main/java/com/microsoft/device/display/samples/twopage/ui/home/HomePage.kt
+++ b/ComposeSamples/TwoPage/src/main/java/com/microsoft/device/display/samples/twopage/ui/home/HomePage.kt
@@ -67,8 +67,9 @@ fun SetupUI(windowInfoRep: WindowInfoRepository) {
     if (isTabletDualMode) {
         viewWidth = LocalConfiguration.current.screenWidthDp / 2
     }
+    val isDualPortraitMode = isAppSpanned && !isHingeHorizontal
 
-    val isDualScreen = (isAppSpanned || isTabletDualMode) && !isHingeHorizontal
+    val isDualScreen = (isDualPortraitMode) || isTabletDualMode
     val pages = setupPages(viewWidth)
     PageViews(pages, isDualScreen, hingeThickness / 2)
 }

--- a/ComposeSamples/TwoPage/src/main/java/com/microsoft/device/display/samples/twopage/ui/home/HomePage.kt
+++ b/ComposeSamples/TwoPage/src/main/java/com/microsoft/device/display/samples/twopage/ui/home/HomePage.kt
@@ -33,7 +33,8 @@ fun SetupUI(windowInfoRep: WindowInfoRepository) {
     val density = LocalDensity.current.density
     var isAppSpanned by remember { mutableStateOf(false) }
     var viewWidth by remember { mutableStateOf(0) }
-    var hingeWidth by remember { mutableStateOf(0) }
+    var hingeThickness by remember { mutableStateOf(0) }
+    var isHingeHorizontal by remember { mutableStateOf(false) }
 
     LaunchedEffect(windowInfoRep) {
         windowInfoRep.windowLayoutInfo
@@ -42,13 +43,19 @@ fun SetupUI(windowInfoRep: WindowInfoRepository) {
                 isAppSpanned = displayFeatures.isNotEmpty()
                 if (isAppSpanned) {
                     val foldingFeature = displayFeatures.first() as FoldingFeature
-                    val vWidth = if (foldingFeature.orientation == FoldingFeature.Orientation.VERTICAL) {
-                        foldingFeature.bounds.left
+                    val vWidth: Int
+
+                    if (foldingFeature.orientation == FoldingFeature.Orientation.VERTICAL) {
+                        isHingeHorizontal = false
+                        vWidth = foldingFeature.bounds.left
+                        hingeThickness = foldingFeature.bounds.width()
                     } else {
-                        foldingFeature.bounds.top
+                        isHingeHorizontal = true
+                        vWidth = foldingFeature.bounds.right
+                        hingeThickness = foldingFeature.bounds.height()
                     }
+
                     viewWidth = (vWidth / density).toInt()
-                    hingeWidth = foldingFeature.bounds.width()
                 }
             }
     }
@@ -61,9 +68,9 @@ fun SetupUI(windowInfoRep: WindowInfoRepository) {
         viewWidth = LocalConfiguration.current.screenWidthDp / 2
     }
 
-    val isDualScreen = isAppSpanned || isTabletDualMode
+    val isDualScreen = (isAppSpanned || isTabletDualMode) && !isHingeHorizontal
     val pages = setupPages(viewWidth)
-    PageViews(pages, isDualScreen, hingeWidth)
+    PageViews(pages, isDualScreen, hingeThickness)
 }
 
 @Composable

--- a/ComposeSamples/TwoPage/src/main/java/com/microsoft/device/display/samples/twopage/ui/home/HomePage.kt
+++ b/ComposeSamples/TwoPage/src/main/java/com/microsoft/device/display/samples/twopage/ui/home/HomePage.kt
@@ -70,7 +70,7 @@ fun SetupUI(windowInfoRep: WindowInfoRepository) {
 
     val isDualScreen = (isAppSpanned || isTabletDualMode) && !isHingeHorizontal
     val pages = setupPages(viewWidth)
-    PageViews(pages, isDualScreen, hingeThickness)
+    PageViews(pages, isDualScreen, hingeThickness / 2)
 }
 
 @Composable

--- a/ComposeSamples/TwoPage/src/main/java/com/microsoft/device/display/samples/twopage/ui/home/SecondPage.kt
+++ b/ComposeSamples/TwoPage/src/main/java/com/microsoft/device/display/samples/twopage/ui/home/SecondPage.kt
@@ -26,18 +26,22 @@ fun SecondPage(modifier: Modifier) {
 fun SecondPageContent() {
     Text(
         text = stringResource(R.string.two_page_page2_title1),
+        color = MaterialTheme.colors.onBackground,
         style = MaterialTheme.typography.h6
     )
     Text(
         text = stringResource(R.string.two_page_page2_text1),
+        color = MaterialTheme.colors.onBackground,
         style = MaterialTheme.typography.body1
     )
     Text(
         text = stringResource(R.string.two_page_page2_title2),
+        color = MaterialTheme.colors.onBackground,
         style = MaterialTheme.typography.h6
     )
     Text(
         text = stringResource(R.string.two_page_page2_text2),
+        color = MaterialTheme.colors.onBackground,
         style = MaterialTheme.typography.body1
     )
     AlignedCaption(

--- a/ComposeSamples/TwoPage/src/main/java/com/microsoft/device/display/samples/twopage/ui/home/ThirdPage.kt
+++ b/ComposeSamples/TwoPage/src/main/java/com/microsoft/device/display/samples/twopage/ui/home/ThirdPage.kt
@@ -26,10 +26,12 @@ fun ThirdPage(modifier: Modifier) {
 fun ThirdPageContent() {
     Text(
         text = stringResource(R.string.two_page_page3_title1),
+        color = MaterialTheme.colors.onBackground,
         style = MaterialTheme.typography.h6
     )
     Text(
         text = stringResource(R.string.two_page_page3_text1),
+        color = MaterialTheme.colors.onBackground,
         style = MaterialTheme.typography.body1
     )
     AlignedCaption(

--- a/ComposeSamples/TwoPage/src/main/java/com/microsoft/device/display/samples/twopage/utils/ViewComponents.kt
+++ b/ComposeSamples/TwoPage/src/main/java/com/microsoft/device/display/samples/twopage/utils/ViewComponents.kt
@@ -28,6 +28,7 @@ fun AlignedCaption(text: String, arrangement: Arrangement.Horizontal) {
     ) {
         Text(
             text = text,
+            color = MaterialTheme.colors.onBackground,
             style = MaterialTheme.typography.caption
         )
     }


### PR DESCRIPTION
Main changes:
- Make sure hinge thickness is updated accordingly depending on device orientation
- Only show two pages if dual portrait or tablet (make dual landscape show one page)
- Half padding between pages for proper alignment (when unspanned, layout measurements only extend to the end of the first screen, but when spanned, layout measurements extend to the middle of the hinge, so the padding until the second page only needs to be the hinge width / 2 , see images below)
![image](https://user-images.githubusercontent.com/33138268/134406588-344b69c2-53d6-40bd-942f-b19358c20fa6.png)
![image](https://user-images.githubusercontent.com/33138268/134406604-d5598ebe-6ce7-4159-b109-aa9f3d1c3e3e.png)

Issues that remain (not sure if they should be addressed in this PR):
- In dual landscape mode, sometimes text is rendered under the hinge
- Layout measurements in dual portrait mode are off (like the one bullet 3 fixes), we may want to change how everything is measured to simplify the code