### PR TITLE
Prevent CompanionPane crash on 6.7 fold-in emulator

### DIFF
--- a/ComposeSamples/CompanionPane/src/main/java/com/microsoft/device/display/samples/companionpane/HomePage.kt
+++ b/ComposeSamples/CompanionPane/src/main/java/com/microsoft/device/display/samples/companionpane/HomePage.kt
@@ -91,7 +91,8 @@ fun SetupUI(windowInfoRep: WindowInfoRepository) {
 
     screenState =
         if (isDualScreen) {
-            if (isHingeHorizontal) ScreenState.DualLandscape else ScreenState.DualPortrait
+            val showDualLandscape = if (isAppSpanned) isHingeHorizontal else isPortrait
+            if (showDualLandscape) ScreenState.DualLandscape else ScreenState.DualPortrait
         } else {
             // NOTE: the LocalConfiguration orientation info should only be used in single screen mode
             if (isPortrait) ScreenState.SinglePortrait else ScreenState.SingleLandscape

--- a/ComposeSamples/CompanionPane/src/main/java/com/microsoft/device/display/samples/companionpane/HomePage.kt
+++ b/ComposeSamples/CompanionPane/src/main/java/com/microsoft/device/display/samples/companionpane/HomePage.kt
@@ -67,40 +67,35 @@ enum class ScreenState {
 @Composable
 fun SetupUI(windowInfoRep: WindowInfoRepository) {
     var screenState by remember { mutableStateOf(ScreenState.SinglePortrait) }
-
-    val isPortrait = LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT
-    screenState = if (isPortrait) {
-        ScreenState.SinglePortrait
-    } else {
-        ScreenState.SingleLandscape
-    }
-
-    val smallestScreenWidthDp = LocalConfiguration.current.smallestScreenWidthDp
-    val isTablet = smallestScreenWidthDp > SMALLEST_TABLET_SCREEN_WIDTH_DP
-    if (isTablet) {
-        screenState = if (isPortrait) {
-            ScreenState.DualLandscape
-        } else {
-            ScreenState.DualPortrait
-        }
-    }
+    var isAppSpanned by remember { mutableStateOf(false) }
+    var isHingeHorizontal by remember { mutableStateOf(false) }
 
     LaunchedEffect(windowInfoRep) {
         windowInfoRep.windowLayoutInfo
             .collect { newLayoutInfo ->
                 val displayFeatures = newLayoutInfo.displayFeatures
-                val isScreenSpanned = displayFeatures.isNotEmpty()
-                if (isScreenSpanned) {
-                    val foldingFeature = displayFeatures.first() as FoldingFeature
-                    val isVertical = foldingFeature.orientation == FoldingFeature.Orientation.VERTICAL
-                    screenState = if (isVertical) {
-                        ScreenState.DualPortrait
-                    } else {
-                        ScreenState.DualLandscape
+                isAppSpanned = displayFeatures.isNotEmpty()
+                if (isAppSpanned) {
+                    val foldingFeature = displayFeatures.first() as? FoldingFeature
+                    foldingFeature?.let {
+                        isHingeHorizontal = it.orientation == FoldingFeature.Orientation.HORIZONTAL
                     }
                 }
             }
     }
+
+    val isPortrait = LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT
+    val smallestScreenWidthDp = LocalConfiguration.current.smallestScreenWidthDp
+    val isTablet = smallestScreenWidthDp > SMALLEST_TABLET_SCREEN_WIDTH_DP
+    val isDualScreen = (isAppSpanned || isTablet)
+
+    screenState =
+        if (isDualScreen) {
+            if (isHingeHorizontal) ScreenState.DualLandscape else ScreenState.DualPortrait
+        } else {
+            // NOTE: the LocalConfiguration orientation info should only be used in single screen mode
+            if (isPortrait) ScreenState.SinglePortrait else ScreenState.SingleLandscape
+        }
 
     TwoPaneLayout(
         pane1 = { Pane1(screenState) },


### PR DESCRIPTION
Something to think about for the future:
May be difficult to make sure our Duo sample apps are compatible with the 6.7 fold in emulator, because the hinge orientation is opposite (device is in portrait mode when hinge is horizontal, while on the Duo the device is in dual landscape mode when the hinge is horizontal)
