### PR TITLE
Update ComposeSamples to Compose 1.0.4

### DIFF
--- a/ComposeSamples/README.md
+++ b/ComposeSamples/README.md
@@ -18,7 +18,7 @@ When importing the code samples into Android Studio, use the **ComposeSamples** 
 
 ## Prerequisites
 
-- Jetpack Compose version: `1.0.2`
+- Jetpack Compose version: `1.0.4`
 
 - AndroidX WindowManager version: `1.0.0-beta02`
 

--- a/ComposeSamples/dependencies.gradle
+++ b/ComposeSamples/dependencies.gradle
@@ -5,7 +5,7 @@
 
 ext {
     gradlePluginVersion = '7.0.3'
-    kotlinVersion = "1.5.21"
+    kotlinVersion = "1.5.31"
     compileSdkVersion = 31
     targetSdkVersion = compileSdkVersion
     minSdkVersion = 23
@@ -32,10 +32,10 @@ ext {
             composeAnimation  : "androidx.compose.animation:animation:$composeAnimationVersion",
     ]
 
-    composeVersion = "1.0.2"
-    activityComposeVersion = "1.3.1"
+    composeVersion = "1.0.4"
+    activityComposeVersion = "1.4.0"
     navigationComposeVersion = "2.4.0-alpha09"
-    composeVersionForNavRail = "1.1.0-alpha06"
+    composeVersionForNavRail = "1.1.0-beta01"
     composeDependencies = [
             composeRuntime          : "androidx.compose.runtime:runtime-livedata:$composeVersion",
             composeMaterial         : "androidx.compose.material:material:$composeVersion",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Jetpack Compose sample code CI](https://github.com/microsoft/surface-duo-app-samples/workflows/App%20samples%20CI/badge.svg) ![Compose Version](https://img.shields.io/badge/Jetpack%20Compose-1.0.2-brightgreen)
+![Jetpack Compose sample code CI](https://github.com/microsoft/surface-duo-app-samples/workflows/App%20samples%20CI/badge.svg) ![Compose Version](https://img.shields.io/badge/Jetpack%20Compose-1.0.4-brightgreen)
 
 # Surface Duo Jetpack Compose
 


### PR DESCRIPTION
also update versions for kotlin and compose activity
(leave navigation compose version at 2.4.0-alpha09 to match current TwoPaneLayout navigation version)